### PR TITLE
Fix a small typo inside file ssh.c

### DIFF
--- a/ssh.c
+++ b/ssh.c
@@ -10536,7 +10536,7 @@ static void do_ssh2_authconn(Ssh ssh, const unsigned char *in, int inlen,
 #ifdef AUTOPASS
 		} else
 		    c_write_str(ssh,
-			dupprintf("%s@%s's passwrod: auto-login\r\n", ssh->username, ssh->savedhost));
+			dupprintf("%s@%s's password: auto-login\r\n", ssh->username, ssh->savedhost));
 #endif
 		/*
 		 * Squirrel away the password. (We may need it later if


### PR DESCRIPTION
... I became aware of this typo when launching the English GUI of iPuTTY, with password string saved inside a session local file ("Auto-login password" feature); the terminal opened contains that typo: 

![typo](https://user-images.githubusercontent.com/9669492/38837660-769d09cc-41db-11e8-8ba7-6657eaddb5c5.jpg)

Thanks 😃 